### PR TITLE
Parsing support for weapon offense

### DIFF
--- a/poe/utils.py
+++ b/poe/utils.py
@@ -831,34 +831,37 @@ def parse_game_item(itemtext):
     for group in groups:
         if group[0].startswith('Rarity:'):
             pobitem['rarity'] = group[0].split(' ')[1].title()
+            
             pobitem['base'] = group[len(group)-1]
+            if 'Superior' in pobitem['base']:
+                pobitem['base'] = pobitem['base'].replace('Superior ', '')
+            if 'Synthesised' in pobitem['base']:
+                # is there a special nature for Synthesised items?
+                # if yes: pobitem['special'].append('Synthesised Item')
+                pobitem['base'] = pobitem['base'].replace('Synthesised', '')
 
             if len(group) > 2:
                 pobitem['name'] = group[1]
 
-        # or group[0].startswith('Armour:') or group[0].startswith('Evasion Rating:') or group[0].startswith('Energy Shield:') or
-        elif group[0].startswith('Quality') or group[0].startswith('Map Tier:'):
+        # defense
+        elif group[0].startswith('Quality') or group[0].startswith('Map Tier:') or group[0].startswith('Chance to Block:') or group[0].startswith('Armour:') or group[0].startswith('Evasion Rating:') or group[0].startswith('Energy Shield:'):
             for line in group:
                 if line.startswith('Quality:'):
-                    pobitem['quality'] = line.replace(
-                        'Quality: +', '').replace('% (augmented)', '')
-                elif line.startswith('Map Tier:') or line.startswith('Item Quantity:') or line.startswith('Item Rarity:'): # map stuff
+                    pobitem['quality'] = line.replace('Quality: +', '').replace('% (augmented)', '')
+                elif line.startswith('Map Tier:') or line.startswith('Item Quantity:') or line.startswith('Item Rarity:') or line.startswith('Monster Pack Size:') or line.startswith('Atlas Region:'): # map stuff
                     pobitem['implicit'].append(line)
                 elif line.startswith('Quality ('):  # catalysts
                     pobitem['implicit'].append(line)
+        # offense
+        elif group[len(group)-1].startswith('Attacks per Second:') or group[len(group)-1].startswith('Weapon Range:'):
+            # this filter is not trivial and not fully tested, due to large differences in weapon types and unique exceptions 
+            # trivial solution would be to check for every weapon type in the game
+            pass
         elif group[0].startswith('Requirements:'):
             pass
         elif group[0].startswith('Sockets:'):
             pass
         elif group[0].startswith('Item Level:'):
-            pass
-        elif group[0].startswith('Energy Shield:'):
-            pass
-        elif group[0].startswith('Armour:'):
-            pass
-        elif group[0].startswith('Evasion Rating:'):
-            pass
-        elif group[0].startswith('Chance to Block:'):
             pass
         elif group[0].startswith('Price:'):
             pass

--- a/poe/utils.py
+++ b/poe/utils.py
@@ -844,11 +844,20 @@ def parse_game_item(itemtext):
                 pobitem['name'] = group[1]
 
         # defense
-        elif group[0].startswith('Quality') or group[0].startswith('Map Tier:') or group[0].startswith('Chance to Block:') or group[0].startswith('Armour:') or group[0].startswith('Evasion Rating:') or group[0].startswith('Energy Shield:'):
+        elif (  group[0].startswith('Quality') or 
+                group[0].startswith('Map Tier:') or 
+                group[0].startswith('Chance to Block:') or 
+                group[0].startswith('Armour:') or 
+                group[0].startswith('Evasion Rating:') or 
+                group[0].startswith('Energy Shield:')):
             for line in group:
                 if line.startswith('Quality:'):
                     pobitem['quality'] = line.replace('Quality: +', '').replace('% (augmented)', '')
-                elif line.startswith('Map Tier:') or line.startswith('Item Quantity:') or line.startswith('Item Rarity:') or line.startswith('Monster Pack Size:') or line.startswith('Atlas Region:'): # map stuff
+                elif (  line.startswith('Map Tier:') or 
+                        line.startswith('Item Quantity:') or 
+                        line.startswith('Item Rarity:') or 
+                        line.startswith('Monster Pack Size:') or 
+                        line.startswith('Atlas Region:')): # map stuff
                     pobitem['implicit'].append(line)
                 elif line.startswith('Quality ('):  # catalysts
                     pobitem['implicit'].append(line)


### PR DESCRIPTION
Add parsing support for weapon offense
Fix parsing for superior and sythesised items

before weapon offense mods were leading to incorrect explicit parsing
now it should correctly identify that mod group and ignore contained mods