### PR TITLE
Ignore cargoquery errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/items.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -51,11 +53,6 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
 # Flask stuff:
 instance/
 .webassets-cache
@@ -74,12 +71,6 @@ target/
 
 # pyenv
 .python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env

--- a/poe/clientbase.py
+++ b/poe/clientbase.py
@@ -35,8 +35,11 @@ class ClientBase:
     @staticmethod
     def extract_cargoquery(data):
         extracted = []
-        for item in data['cargoquery']:
-            extracted.append(item['title'])
+        if 'error' in data:
+            print(data['error'])
+        else:
+            for item in data['cargoquery']:
+                extracted.append(item['title'])
         return extracted
 
     @staticmethod
@@ -129,7 +132,7 @@ class ClientBase:
             vendor_params = {
                 'tables': "vendor_rewards",
                 'fields': "act,classes",
-                'where': f'''reward="{gem['name']}"'''
+                'where': f'''reward="{gem['name']}"''',
             }
             vendors_raw = req(url, params=vendor_params)
             vendors = self.extract_cargoquery(vendors_raw)
@@ -142,7 +145,6 @@ class ClientBase:
                 'where': f'''_pageName="{gem['name']}"'''
             }
             stats_raw = req(url, params=stats_params)
-            print(stats_raw)
             stats_list = self.extract_cargoquery(stats_raw)
             stats = {}
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import poe.client
+
+client = poe.client.Client()
+items = client.find_items({'name': 'freezing pulse'})
+for item in items:
+	print(item.__dict__)


### PR DESCRIPTION
Gem rewards cargoqueries are returning
```
{'code': 'db_error', 'info': 'A database query error has occurred. This may indicate a bug in the software.',
'*': 'See https://pathofexile.gamepedia.com/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce&gt; for notice of API deprecations and breaking changes.'}
```
which causes the entire `find_items()` call to fail.